### PR TITLE
Place the social icons better for small screens.

### DIFF
--- a/html.tpl.php
+++ b/html.tpl.php
@@ -86,12 +86,12 @@ $htmlattributes = "lang=\"{$language->language}\" dir=\"{$language->dir}\" $rdf_
         </script>
         
         <!-- AddThis Button BEGIN -->
-		<div class="addthis_toolbox addthis_floating_style addthis_16x16_style" style="left:50px;top:50px;">
-		<a class="addthis_button_preferred_1"></a>
-		<a class="addthis_button_preferred_2"></a>
-		<a class="addthis_button_preferred_3"></a>
-		<a class="addthis_button_preferred_4"></a>
-		<a class="addthis_button_compact"></a>
+		<div class="addthis_toolbox addthis_floating_style addthis_16x16_style">
+			<a class="addthis_button_preferred_1"></a>
+			<a class="addthis_button_preferred_2"></a>
+			<a class="addthis_button_preferred_3"></a>
+			<a class="addthis_button_preferred_4"></a>
+			<a class="addthis_button_compact"></a>
 		</div>
 		<script type="text/javascript">var addthis_config = {"data_track_addressbar":true,data_ga_property: 'UA-1527676-1',data_ga_social : true};</script>
 		<script type="text/javascript" src="https://s7.addthis.com/js/300/addthis_widget.js#pubid=ra-4e1bd9e270c39903"></script>

--- a/sass/_addthis.scss
+++ b/sass/_addthis.scss
@@ -1,0 +1,33 @@
+// Styles the social-sharing widget
+@import 'util/util'; // Foundation utilities
+
+@mixin addthis-position {
+  left: 4px;
+  top: 56px;
+
+  @include breakpoint(medium) {
+    left: 50px;
+  }
+
+  a:first-child {
+    margin-top: 4px;
+  }
+}
+
+@mixin addthis-container {
+  border-radius: 0;
+  box-shadow: 0 0 10px 0 #333;
+}
+
+@mixin addthis {
+  .addthis {
+    &_floating_style {
+      @include addthis-position;
+
+      // Don't like nesting but need the specificity
+      &.addthis_16x16_style {
+        @include addthis-container;
+      }
+    }
+  }
+}

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -134,7 +134,10 @@ h2.pagetitle {
 }
 
 @import 'article-date';
+@import 'addthis';
+
 @include article-date;
+@include addthis;
 
 .comment .author {
 	text-align:			right;


### PR DESCRIPTION
Better social icon placement on small screens. Also restyles the box to be consistent with other panels on the page by removing rounded corners and adding drop shadows.

<img width="985" alt="screen shot 2018-12-03 at 3 15 09 pm" src="https://user-images.githubusercontent.com/105728/49407698-4db35000-f70e-11e8-84f4-4ce8e3300b6d.png">

