### PR TITLE
docs(badges): replace greenkeeper with dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Build Status](https://travis-ci.org/amclin/amc-drupal-theme.svg?branch=master)](https://travis-ci.org/amclin/amc-drupal-theme)
 [![dependencies Status](https://david-dm.org/amclin/amc-drupal-theme/status.svg)](https://david-dm.org/amclin/amc-drupal-theme)
-[![devDependencies Status](https://david-dm.org/amclin/amc-drupal-theme/dev-status.svg)](https://david-dm.org/amclin/amc-drupal-theme?type=dev) [![Greenkeeper badge](https://badges.greenkeeper.io/amclin/amc-drupal-theme.svg)](https://greenkeeper.io/)
+[![devDependencies Status](https://david-dm.org/amclin/amc-drupal-theme/dev-status.svg)](https://david-dm.org/amclin/amc-drupal-theme?type=dev) [![Dependabot Status](https://badgen.net/dependabot/amclin/amc-drupal-theme/?icon=dependabot)](https://dependabot.com)
 # amc-drupal-theme
 Drupal theme used for [AnthonyMcLin.com](https://anthonymclin.com)
 


### PR DESCRIPTION
Greenkeeper is shutting down: https://greenkeeper.io/

This repo is already updated to be managed via Dependabot instead